### PR TITLE
AHT1x -> AHT2x

### DIFF
--- a/library.json
+++ b/library.json
@@ -81,7 +81,7 @@
     {"name":"Adafruit SCD30", "owner":"adafruit","version":"1.0.8"},
     {"name":"Adafruit BusIO", "owner":"adafruit","version":"1.11.6"},
     {"name":"AM232X", "owner":"robtillaart", "version":"0.4.1"},
-    {"name":"AHT10", "owner":"enjoyneering","version":"1.1.0"},
+    {"name":"AHTxx", "owner":"enjoyneering","version":"1.1.6"},
     {"name":"sps30", "owner":"paulvha","version":"1.4.12"},
     {"name":"MH-Z19", "owner":"wifwaf", "version":"1.5.3"},
     {"name":"Sensirion Core","owner":"sensirion","version":"0.5.3"},

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ url=https://github.com/kike-canaries/canairio_sensorlib
 sentence=Air quality particle meter and CO2 sensors manager for multiple models.
 paragraph=Generic sensor manager, abstratctions and bindings of multiple air sensors libraries: Honeywell, Plantower, Panasonic, Sensirion, Nova, etc. and CO2 sensors. Also it handling others environment sensors. This library is for general purpose but also is the sensors library base of CanAirIO project.
 category=sensors
-depends=AM232X,Adafruit Unified Sensor,sps30,Adafruit BME280 Library,AHT10,Adafruit BusIO,Adafruit SHT31 Library,DHT_nonblocking,MH-Z19,SparkFun SCD30 Arduino Library,CM1106_UART,SN-GCJA5,Adafruit BME680 Library,S8_UART,Sensirion I2C SCD4x
+depends=AM232X,Adafruit Unified Sensor,sps30,Adafruit BME280 Library,AHTxx,Adafruit BusIO,Adafruit SHT31 Library,DHT_nonblocking,MH-Z19,SparkFun SCD30 Arduino Library,CM1106_UART,SN-GCJA5,Adafruit BME680 Library,S8_UART,Sensirion I2C SCD4x
 license=GPL-3.0-only

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ lib_deps =
 	adafruit/Adafruit SCD30 @ 1.0.8
 	adafruit/Adafruit BusIO @ 1.11.6
 	robtillaart/AM232X @ 0.4.1
-	enjoyneering/AHT10 @ 1.1.0
+	enjoyneering/AHTxx @ 1.1.6
 	paulvha/sps30 @ 1.4.12
 	wifwaf/MH-Z19 @ 1.5.3
 	sensirion/Sensirion Core @ 0.5.3

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -907,13 +907,13 @@ void Sensors::bme680Read() {
 }
 
 void Sensors::aht10Read() {
-    float humi1 = aht10.readHumidity();
-    float temp1 = aht10.readTemperature();
+    float humi1 = aht20.readHumidity();
+    float temp1 = aht20.readTemperature();
     if (humi1 != 255) humi = humi1;
     if (temp1 != 255) {
         temp = temp1-toffset;
         dataReady = true;
-        DEBUG("-->[SLIB] AHT10 read\t\t: done!");
+        DEBUG("-->[SLIB] AHT20 read\t\t: done!");
         unitRegister(UNIT::TEMP);
         unitRegister(UNIT::HUM);
     }
@@ -1416,8 +1416,8 @@ void Sensors::bme680Init() {
 
 void Sensors::aht10Init() {
     sensorAnnounce(SENSORS::SAHT10);
-    aht10 = AHT10(AHT10_ADDRESS_0X38);
-    if (!aht10.begin()) return; 
+    aht20 = AHTxx(AAHTXX_ADDRESS_X38, AHT2x_SENSOR);
+    if (!aht20.begin()) return; 
     sensorRegister(SENSORS::SAHT10);
 }
 

--- a/src/Sensors.hpp
+++ b/src/Sensors.hpp
@@ -1,7 +1,7 @@
 #ifndef Sensors_hpp
 #define Sensors_hpp
 
-#include <AHT10.h>
+#include <AHTxx.h>
 #include <AM232X.h>
 #include <Adafruit_BME280.h>
 #include <Adafruit_BME680.h>
@@ -178,7 +178,7 @@ class Sensors {
     // BME680 (Humidity, Gas, IAQ, Pressure, Altitude and Temperature)
     Adafruit_BME680 bme680;
     // AHT10
-    AHT10 aht10;
+    AHTxx aht20;
     // SHT31
     Adafruit_SHT31 sht31;
     // DHT sensor


### PR DESCRIPTION
Using new AHTxx library, as AHT10 lib has been deprecated.
Very hacky implementation, will not work with AHT10 sensors anymore!

TODO: autodetect AHT10 vs AHT20?